### PR TITLE
Add Render Docker deployment (Playwright + FFmpeg) and health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+output/
+.DS_Store
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/playwright:v1.53.0-jammy
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=10000
+
+EXPOSE 10000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ Deschide apoi:
 http://localhost:3000
 ```
 
+## Deploy pe Render (Web Service)
+
+Repo-ul include acum configurare minimă pentru Render:
+
+- `Dockerfile` bazat pe imaginea Playwright + instalare `ffmpeg`
+- `render.yaml` pentru Web Service Docker
+- endpoint de health check la `GET /health`
+
+Pași rapizi:
+
+1. În Render: **New → Web Service**
+2. Conectezi repo-ul GitHub
+3. Render detectează `render.yaml` + Docker runtime
+4. Opțional setezi `Health Check Path` la `/health`
+
+> Notă: GitHub Pages nu poate rula backend Node/Playwright/FFmpeg. Aplicația trebuie hostată ca Web Service.
+
 ## Flux
 
 - UI-ul din `public/index.html` trimite payload-ul la `POST /api/render`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "link-video-automation",
+  "name": "link-video-editor-studio",
   "version": "1.0.0",
   "description": "HTML + Node.js + Playwright + FFmpeg automation for product demo videos",
   "main": "server.js",
@@ -11,9 +11,7 @@
   },
   "dependencies": {
     "express": "^4.21.2",
+    "playwright": "^1.53.0",
     "uuid": "^11.1.0"
-  },
-  "devDependencies": {
-    "playwright": "^1.54.2"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: link-video-editor-studio
+    runtime: docker
+    plan: starter
+    autoDeploy: true

--- a/server.js
+++ b/server.js
@@ -18,6 +18,10 @@ app.use(express.json({ limit: '10mb' }));
 app.use('/output', express.static(path.join(__dirname, 'output')));
 app.use(express.static(path.join(__dirname, 'public')));
 
+app.get('/health', (_req, res) => {
+  res.status(200).json({ ok: true });
+});
+
 app.get('/api/health', async (_req, res) => {
   res.json({ ok: true, presets: presets.length });
 });
@@ -73,5 +77,5 @@ app.get('*', (_req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`Link Video Automation listening on http://localhost:${PORT}`);
+  console.log(`Server running on ${PORT}`);
 });


### PR DESCRIPTION
### Motivation
- Provide a minimal, production-ready deployment configuration so the app can run as a Render Web Service with Playwright and FFmpeg available in the container.
- Ensure the service exposes a standard health endpoint and uses the configured container `PORT` so Render health checks work reliably.
- Document the Render deployment steps and avoid committing generated/runtime artifacts.

### Description
- Added a `Dockerfile` based on the official Playwright image with `ffmpeg` installed and `npm install --omit=dev` for production installs (exposes `PORT=10000`).
- Added `render.yaml` to define a Docker Web Service (`name: link-video-editor-studio`, `runtime: docker`, `autoDeploy: true`).
- Updated `server.js` to add a `GET /health` endpoint and simplified startup log to use the `PORT` environment variable.
- Updated `package.json` metadata (`name` changed to `link-video-editor-studio`) and moved `playwright` into runtime dependencies for container usage, updated `README.md` with Render deploy instructions, and added `.gitignore`.

### Testing
- Ran `node --check server.js` which completed successfully.
- Attempted `npm install --package-lock-only` which failed with an npm registry `403` (registry permissions), so package-lock generation was not completed in this environment.
- Started the app with `npm start` and observed the startup log `Server running on 3000`, indicating the server launched successfully in the container-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65f6916008322832ebc6c25197fdb)