### PR TITLE
Fix /api/render crash when creating new jobs

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,35 +31,43 @@ app.get('/api/presets', (_req, res) => {
 });
 
 app.post('/api/render', async (req, res) => {
-  const jobId = uuidv4();
-  const payload = req.body || {};
+  try {
+    const jobId = uuidv4();
+    const payload = req.body || {};
 
-  const config = {
-    ...payload,
-    jobId
-  };
-
-  const paths = getJobPaths(jobId);
-  await fs.writeFile(paths.requestJson, JSON.stringify(config, null, 2), 'utf8');
-
-  res.json({
-    ok: true,
-    jobId,
-    status: 'queued',
-    requestPath: paths.requestJson,
-    statusUrl: `/api/render/${jobId}`,
-    outputBaseUrl: `/output/${jobId}`
-  });
-
-  runAutomation(config).catch(async (error) => {
-    const failStatus = {
-      ok: false,
-      jobId,
-      state: 'failed',
-      error: error instanceof Error ? error.message : String(error)
+    const config = {
+      ...payload,
+      jobId
     };
-    await fs.writeFile(paths.statusJson, JSON.stringify(failStatus, null, 2), 'utf8');
-  });
+
+    const paths = getJobPaths(jobId);
+    await fs.mkdir(paths.baseDir, { recursive: true });
+    await fs.writeFile(paths.requestJson, JSON.stringify(config, null, 2), 'utf8');
+
+    res.json({
+      ok: true,
+      jobId,
+      status: 'queued',
+      requestPath: paths.requestJson,
+      statusUrl: `/api/render/${jobId}`,
+      outputBaseUrl: `/output/${jobId}`
+    });
+
+    runAutomation(config).catch(async (error) => {
+      const failStatus = {
+        ok: false,
+        jobId,
+        state: 'failed',
+        error: error instanceof Error ? error.message : String(error)
+      };
+      await fs.writeFile(paths.statusJson, JSON.stringify(failStatus, null, 2), 'utf8');
+    });
+  } catch (error) {
+    res.status(500).json({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
 });
 
 app.get('/api/render/:jobId', async (req, res) => {


### PR DESCRIPTION
### Motivation
- Prevent the server from crashing with `ENOENT` when a new render job is posted and the job output directory doesn't exist.
- Return a controlled error response from the endpoint instead of letting initialization failures bring down the Node process.

### Description
- Ensure the job output directory is created before writing `request.json` by calling `fs.mkdir(paths.baseDir, { recursive: true })` in the `POST /api/render` handler.
- Wrap the `POST /api/render` logic in a `try/catch` so setup errors return a structured `500` JSON response instead of crashing the server.
- Preserve the existing `runAutomation(config)` flow and keep the existing failure handler that writes `status.json` when automation itself fails.

### Testing
- Started the server with `npm run -s start` and confirmed it launched successfully.
- Verified the health endpoint with `curl -sS http://127.0.0.1:3000/health` and received a successful response.
- Posted a sample job with `curl -sS -X POST http://127.0.0.1:3000/api/render ...` and confirmed the endpoint returns a queued job JSON without crashing the server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6611b79588322986909bf9dc6ce87)