### PR TITLE
Add GitHub Pages fallback and robust API helpers for static UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,10 @@
         <label for="workflowNotes">Workflow (pre-roll + de evitat)</label>
         <textarea id="workflowNotes" class="mono" readonly></textarea>
       </div>
+      <div class="field">
+        <label for="backendUrl">Backend URL (opțional pentru GitHub Pages)</label>
+        <input id="backendUrl" placeholder="http://localhost:3000" />
+      </div>
 
       <div class="grid2">
         <div class="field">
@@ -148,10 +152,44 @@
     let presets = [];
     let pollHandle = null;
 
+    function getApiBase() {
+      return $('backendUrl').value.trim().replace(/\/+$/, '');
+    }
+
+    function apiUrl(path) {
+      const base = getApiBase();
+      return base ? `${base}${path}` : path;
+    }
+
+    async function parseJsonSafe(res) {
+      const text = await res.text();
+      try {
+        return JSON.parse(text);
+      } catch (_error) {
+        return { ok: false, error: `Răspuns invalid (${res.status})`, raw: text.slice(0, 180) };
+      }
+    }
+
+    async function apiFetch(path, options = {}) {
+      const res = await fetch(apiUrl(path), options);
+      const data = await parseJsonSafe(res);
+      if (!res.ok) {
+        const message = data?.error || `HTTP ${res.status}`;
+        throw new Error(message);
+      }
+      return data;
+    }
+
     async function loadPresets() {
-      const res = await fetch('/api/presets');
-      const data = await res.json();
-      presets = data.presets || [];
+      try {
+        const data = await apiFetch('/api/presets');
+        presets = data.presets || [];
+      } catch (_error) {
+        const localRes = await fetch('./presets.json');
+        const localData = await parseJsonSafe(localRes);
+        presets = localData.presets || [];
+        setStatus('Backend indisponibil. Am încărcat preset-urile locale (mod demo static).');
+      }
     }
 
     function applyPreset(index) {
@@ -201,18 +239,26 @@
     }
 
     async function healthCheck() {
-      const res = await fetch('/api/health');
-      const data = await res.json();
-      setStatus(JSON.stringify(data, null, 2));
+      try {
+        const data = await apiFetch('/api/health');
+        setStatus(JSON.stringify(data, null, 2));
+      } catch (error) {
+        setStatus(`Health check eșuat: ${error.message}\nTip: completează "Backend URL" (ex: http://localhost:3000).`);
+      }
     }
 
     async function poll(jobId) {
       if (pollHandle) clearInterval(pollHandle);
       pollHandle = setInterval(async () => {
-        const res = await fetch(`/api/render/${jobId}`);
-        const data = await res.json();
-        setStatus(JSON.stringify(data, null, 2));
-        if (['completed', 'failed'].includes(data.state)) {
+        try {
+          const data = await apiFetch(`/api/render/${jobId}`);
+          setStatus(JSON.stringify(data, null, 2));
+          if (['completed', 'failed'].includes(data.state)) {
+            clearInterval(pollHandle);
+            pollHandle = null;
+          }
+        } catch (error) {
+          setStatus(`Polling oprit: ${error.message}`);
           clearInterval(pollHandle);
           pollHandle = null;
         }
@@ -222,16 +268,15 @@
     async function runJob() {
       try {
         const payload = payloadFromForm();
-        const res = await fetch('/api/render', {
+        const data = await apiFetch('/api/render', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        const data = await res.json();
         setStatus(JSON.stringify(data, null, 2));
         await poll(data.jobId);
       } catch (error) {
-        setStatus(`Eroare: ${error.message}`);
+        setStatus(`Eroare: ${error.message}\nTip: pe GitHub Pages trebuie un backend separat (ex: local/Render).`);
       }
     }
 
@@ -240,6 +285,16 @@
     $('loadPreset3').addEventListener('click', () => applyPreset(2));
     $('runBtn').addEventListener('click', runJob);
     $('healthBtn').addEventListener('click', healthCheck);
+
+    $('backendUrl').addEventListener('change', () => {
+      localStorage.setItem('backendUrl', $('backendUrl').value.trim());
+    });
+
+    $('backendUrl').value = localStorage.getItem('backendUrl') || '';
+
+    if (location.hostname.endsWith('github.io') && !$('backendUrl').value) {
+      setStatus('Ești pe GitHub Pages (static). Completează "Backend URL" pentru health/render.');
+    }
 
     loadPresets().then(() => { if (presets[0]) applyPreset(0); });
   </script>

--- a/public/presets.json
+++ b/public/presets.json
@@ -1,0 +1,745 @@
+{
+  "presets": [
+    {
+      "name": "CLIP 1 — Alpis Fusion CRM Premium",
+      "durationSeconds": 40,
+      "url": "https://laurandreea10.github.io/Alpis-Fusion-CRM-premium/",
+      "message": "Acest produs are profunzime: 18 module integrate, command palette, flow builder și facturare completă într-un singur ecran.",
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "output": {
+        "encoder": "libx264",
+        "crf": 18,
+        "fpsCapture": 30,
+        "fpsFinal": 24,
+        "canvasResolution": "1920x1080",
+        "outputResolution": "1280x720",
+        "preset": "veryfast"
+      },
+      "preRoll": [
+        "Deschide URL-ul și așteaptă hero screen-ul cu orbs-urile animate.",
+        "Dacă pornește turul ghidat: skip/close rapid ca să ajungi pe dashboard.",
+        "Generează date demo dacă aplicația pornește goală și poziționează-te pe Dashboard cu KPI-uri vizibile."
+      ],
+      "avoid": [
+        "Nu comuta dark/light theme.",
+        "Nu intra în Settings/Export.",
+        "Nu scrie texte lungi în formulare."
+      ],
+      "shots": [
+        {
+          "type": "wait",
+          "ms": 2200,
+          "note": "00:00-00:04 dashboard idle cu KPI-uri animate"
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Skip",
+            "Sari",
+            "Închide",
+            "Close"
+          ],
+          "timeoutMs": 1200
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "Demo data",
+            "Generează date",
+            "Generate"
+          ],
+          "timeoutMs": 1500
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Dashboard"
+          ],
+          "timeoutMs": 1500
+        },
+        {
+          "type": "wait",
+          "ms": 1700
+        },
+        {
+          "type": "hover",
+          "selector": [
+            "[data-kpi-card]",
+            ".kpi-card",
+            ".metric-card",
+            ".card"
+          ],
+          "timeoutMs": 7000,
+          "note": "00:04-00:06 hover KPI pentru tooltip"
+        },
+        {
+          "type": "wait",
+          "ms": 1200
+        },
+        {
+          "type": "pressAny",
+          "keys": [
+            "Meta+K",
+            "Control+K"
+          ],
+          "note": "00:06-00:10 command palette"
+        },
+        {
+          "type": "wait",
+          "ms": 600
+        },
+        {
+          "type": "type",
+          "selector": [
+            "input[type=\"search\"]",
+            "input",
+            "[contenteditable=\"true\"]"
+          ],
+          "text": "clien",
+          "delay": 170
+        },
+        {
+          "type": "wait",
+          "ms": 700
+        },
+        {
+          "type": "press",
+          "keys": "Enter"
+        },
+        {
+          "type": "wait",
+          "ms": 2600
+        },
+        {
+          "type": "hover",
+          "selector": [
+            "[data-client-row]",
+            ".client-row",
+            "tbody tr",
+            ".list-item"
+          ],
+          "timeoutMs": 7000,
+          "note": "00:10-00:14 hover client preview"
+        },
+        {
+          "type": "wait",
+          "ms": 1600
+        },
+        {
+          "type": "click",
+          "selector": [
+            "[data-client-row]",
+            ".client-row",
+            "tbody tr",
+            ".list-item"
+          ],
+          "timeoutMs": 7000,
+          "note": "00:14-00:18 open client detail panel"
+        },
+        {
+          "type": "wait",
+          "ms": 2100
+        },
+        {
+          "type": "press",
+          "keys": "Escape"
+        },
+        {
+          "type": "wait",
+          "ms": 500
+        },
+        {
+          "type": "press",
+          "keys": "P",
+          "note": "00:18-00:20 pipeline shortcut"
+        },
+        {
+          "type": "wait",
+          "ms": 1600
+        },
+        {
+          "type": "drag",
+          "source": "[draggable=\"true\"], .deal-card, .kanban-card",
+          "target": ".kanban-column:nth-child(2), [data-column=\"contacted\"]",
+          "timeoutMs": 8000,
+          "note": "00:20-00:26 drag deal între coloane"
+        },
+        {
+          "type": "wait",
+          "ms": 1200
+        },
+        {
+          "type": "press",
+          "keys": "B",
+          "note": "00:26-00:30 bookings"
+        },
+        {
+          "type": "wait",
+          "ms": 1000
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "Creează booking nou",
+            "Create booking",
+            "booking"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 700
+        },
+        {
+          "type": "fillSmart",
+          "values": [
+            "Demo Client",
+            "26/05/2026",
+            "10:00",
+            "Consultanță rapidă"
+          ]
+        },
+        {
+          "type": "wait",
+          "ms": 1000
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "fact",
+            "invoice",
+            "⊡"
+          ],
+          "timeoutMs": 7000,
+          "note": "00:30-00:34 generare factură"
+        },
+        {
+          "type": "wait",
+          "ms": 900
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "Print Invoice PDF",
+            "Print",
+            "PDF"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1300
+        },
+        {
+          "type": "press",
+          "keys": "Escape"
+        },
+        {
+          "type": "wait",
+          "ms": 600
+        },
+        {
+          "type": "press",
+          "keys": "A",
+          "note": "00:34-00:38 automatizări / flow builder"
+        },
+        {
+          "type": "wait",
+          "ms": 2200
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Dashboard"
+          ],
+          "timeoutMs": 1500
+        },
+        {
+          "type": "scroll",
+          "pixels": -180,
+          "speedPxPerSecond": 180,
+          "note": "00:38-00:40 revenire finală"
+        }
+      ]
+    },
+    {
+      "name": "CLIP 2 — ClientFlow SaaS",
+      "durationSeconds": 30,
+      "url": "https://laurandreea10.github.io/ClientFlow-SaaS-CRM-task-manager-automation-suite/",
+      "message": "Mobile-first, rapid, cu tasks + calendar + clients + invoicing + availability + content studio într-un singur flux.",
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "output": {
+        "encoder": "libx264",
+        "crf": 18,
+        "fpsCapture": 30,
+        "fpsFinal": 24,
+        "canvasResolution": "1920x1080",
+        "outputResolution": "1280x720",
+        "preset": "veryfast"
+      },
+      "preRoll": [
+        "Deschide URL-ul în 1280x720.",
+        "Asigură date demo (min 3 clienți, 5 task-uri).",
+        "Plecăm din Dashboard."
+      ],
+      "avoid": [
+        "Nu intra în Client Portal simulat.",
+        "Nu scrie texte lungi în Content Studio."
+      ],
+      "shots": [
+        {
+          "type": "wait",
+          "ms": 3000,
+          "note": "Dashboard intro"
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Tasks",
+            "Task"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1500
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            ".status-badge",
+            "select"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1400
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Calendar"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1600
+        },
+        {
+          "type": "hover",
+          "selector": [
+            ".calendar-day",
+            "[data-day]",
+            "td"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1400
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Clients",
+            "Client"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1400
+        },
+        {
+          "type": "click",
+          "selector": [
+            "[data-client-row]",
+            ".client-row",
+            "tbody tr",
+            ".list-item"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1800
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Invoic",
+            "Factur"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1400
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "Export PDF",
+            "PDF"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1600
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Availability",
+            "Dispon"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1300
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "sample",
+            "Use sample"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1700
+        },
+        {
+          "type": "click",
+          "selector": [
+            "a",
+            "button",
+            "[role=\"tab\"]"
+          ],
+          "textContains": [
+            "Content",
+            "Studio"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1100
+        },
+        {
+          "type": "type",
+          "selector": [
+            "textarea",
+            "input"
+          ],
+          "text": "Idee: ofertă rapidă pentru lead-uri calde",
+          "delay": 80
+        },
+        {
+          "type": "wait",
+          "ms": 600
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "label"
+          ],
+          "textContains": [
+            "Instagram",
+            "LinkedIn"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 700
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]"
+          ],
+          "textContains": [
+            "Generează",
+            "Generate"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1600
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "label"
+          ],
+          "textContains": [
+            "EN",
+            "RO"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1500
+        }
+      ]
+    },
+    {
+      "name": "CLIP 3 — Alpis Impact Path",
+      "durationSeconds": 35,
+      "url": "https://laurandreea10.github.io/ALPIS-ImpactPath/",
+      "message": "Parcurs interactiv step-by-step: progres vizibil și CTA contextual la final.",
+      "viewport": {
+        "width": 1280,
+        "height": 720
+      },
+      "output": {
+        "encoder": "libx264",
+        "crf": 18,
+        "fpsCapture": 30,
+        "fpsFinal": 24,
+        "canvasResolution": "1920x1080",
+        "outputResolution": "1280x720",
+        "preset": "veryfast"
+      },
+      "preRoll": [
+        "Deschide demo-ul live.",
+        "Resetează parcursul la pasul 1 din N (0%).",
+        "Dacă există variantă statică, arată doar 2-3 secunde pentru contrast."
+      ],
+      "avoid": [
+        "Nu scroll lung pe pagină statică.",
+        "Nu sări peste pași.",
+        "Nu adăuga subtitluri on-screen."
+      ],
+      "shots": [
+        {
+          "type": "wait",
+          "ms": 2500,
+          "note": "Intro/contrast scurt"
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Start",
+            "Începe",
+            "Reset"
+          ],
+          "timeoutMs": 1600
+        },
+        {
+          "type": "wait",
+          "ms": 1300
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Continuă",
+            "Continue",
+            "Next"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1800
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "label",
+            "button",
+            "[role=\"button\"]",
+            "input[type=\"radio\"] + *"
+          ],
+          "timeoutMs": 1300
+        },
+        {
+          "type": "wait",
+          "ms": 600
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Continuă",
+            "Continue",
+            "Next"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1800
+        },
+        {
+          "type": "clickOptional",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            ".option",
+            ".choice"
+          ],
+          "timeoutMs": 1300
+        },
+        {
+          "type": "wait",
+          "ms": 700
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Continuă",
+            "Continue",
+            "Next"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1800
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "Continuă",
+            "Continue",
+            "Next"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 1800
+        },
+        {
+          "type": "click",
+          "selector": [
+            "button",
+            "[role=\"button\"]",
+            "a"
+          ],
+          "textContains": [
+            "CTA",
+            "Finalizează",
+            "Submit",
+            "Trimite",
+            "Get Started"
+          ],
+          "timeoutMs": 7000
+        },
+        {
+          "type": "wait",
+          "ms": 2200
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- The UI on GitHub Pages failed because it assumed an API backend at the same origin, so users visiting the static site could not load presets or trigger renders.
- Provide a simple way for static-hosted pages to point at a real backend and present clearer errors when the API is unavailable.

### Description
- Added an optional `Backend URL` input to the web UI and persisted it to `localStorage` so GitHub Pages can target an external backend (`public/index.html`).
- Implemented `getApiBase`, `apiUrl`, `parseJsonSafe` and `apiFetch` helpers and rewired `loadPresets`, `healthCheck`, `poll` and `runJob` to use them for safer fetches and clearer HTTP/JSON error handling (`public/index.html`).
- Added a static fallback `public/presets.json` (generated from `src/presets.js`) that `loadPresets` uses when `/api/presets` is unreachable, and improved status messages to guide users on static hosting limitations.

### Testing
- Ran `npm run validate` which completed successfully and reported validated inline script blocks.
- Started the server (`node server.js`) and verified the health endpoint with `curl http://127.0.0.1:3000/api/health`, which returned a successful JSON response.
- Verified the UI now loads local `public/presets.json` when the API is unavailable and displays the new guidance/status messages (manual verification in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66f368ab08322bba4fc3b1764a20a)