### PR TITLE
docs: clarify GitHub Pages activation and manual MP4 render flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ http://localhost:3000
 - `.github/workflows/render-video.yml` — randare manuală (`workflow_dispatch`) cu input-uri `clip_url`, `clip_title`, `duration`
 - `.github/workflows/release-pack.yml` — generează ZIP și îl publică în Release pentru tag-uri `v*`
 
+## Activare GitHub Pages + randare MP4 din Actions
+
+1. În GitHub repo: **Settings → Pages**.
+2. La **Source**, selectezi **GitHub Actions**.
+3. Faci push pe branch-ul `main` (workflow-ul `Deploy Pages` pornește automat).
+4. Când vrei un MP4 artifact, intri în tab-ul **Actions** și rulezi manual workflow-ul **Render Video**.
+5. După finalizare, descarci artifact-ul `rendered-video-<run_id>` din run summary.
+
 ## Randare manuală în Actions
 
 1. Deschizi tab-ul **Actions**.


### PR DESCRIPTION
### Motivation
- Clarify how to enable GitHub Pages via Actions and how to manually trigger the existing Actions-based render to obtain MP4 artifacts so users can publish the site and produce downloadable videos.

### Description
- Add a new README section `Activare GitHub Pages + randare MP4 din Actions` with step-by-step instructions to set Pages `Source` to `GitHub Actions`, push to `main` to trigger the `Deploy Pages` workflow, run the `Render Video` workflow manually from the Actions tab, and download the `rendered-video-<run_id>` artifact; the change is confined to `README.md`.

### Testing
- Ran `npm run validate` which completed successfully and reported validation of inline scripts in `public/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6725a5f9883229a6b54984bc6b939)