### PR TITLE
docs: clarify Render Video trigger behavior and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ http://localhost:3000
    - `duration`
 4. Descarci artifact-ul `rendered-video-<run_id>` din run summary.
 
+### Notițe importante despre `render-video.yml`
+
+- Trigger-ul `push.tags` nu are input-uri interactive în GitHub Actions. Din acest motiv, workflow-ul folosește valori fallback (`https://example.com`, `Tagged render`, `40`) când pornește din push pe tag.
+- Pentru clipuri reale (URL + titlu + durată corectă), rulează workflow-ul din **Actions → Render Video → Run workflow** (trigger `workflow_dispatch`).
+- Dacă vrei mai multe shot-uri reale, înlocuiește blocul `plan.json` generat în workflow cu planul exportat din aplicație.
+- Artifactele de workflow și release assets sunt mecanisme diferite și pot coexista fără probleme:
+  - artifactul este atașat rulării din Actions;
+  - release asset-ul este atașat release-ului/tag-ului.
+
 ## Deploy pe Render (Web Service)
 
 Repo-ul include configurare minimă pentru Render:


### PR DESCRIPTION
### Motivation
- Clarify how the `render-video.yml` workflow behaves when triggered by tag pushes (no interactive inputs) and provide guidance for running real renders and publishing outputs.

### Description
- Added a new `Notițe importante despre render-video.yml` section to `README.md` that explains that `push.tags` runs use fallback values (`https://example.com`, `Tagged render`, `40`), recommends using the `workflow_dispatch` run from the Actions tab for real clips, documents replacing the generated `plan.json` with an exported plan for multi-shot renders, and clarifies the difference between workflow artifacts and release assets.
- The only code/documentation file changed is `README.md` (added 9-line notes block with the above guidance).

### Testing
- Ran the repository validation via `npm run validate` which completed successfully and reported `Validated 1 inline <script> blocks in public/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e674d9ca60832292c5bf5669884577)