### PR TITLE
Add Export plan button and JSON plan builder in UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,7 @@
       <div class="toolbar">
         <button class="primary" id="runBtn">Rulează automatizarea</button>
         <button class="secondary" id="healthBtn">Health check</button>
+        <button class="secondary" id="exportPlanBtn">Export plan</button>
       </div>
 
       <p class="muted">Tipuri suportate pentru shots: <span class="mono">wait, click, clickOptional, hover, type, press, pressAny, drag, scroll, fillSmart, evaluate</span>.</p>
@@ -234,6 +235,76 @@
       };
     }
 
+    function slugify(value) {
+      return String(value || 'latest')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'latest';
+    }
+
+    function parseNumber(value, fallback) {
+      const number = Number(value);
+      return Number.isFinite(number) ? number : fallback;
+    }
+
+    function buildPlanFromForm() {
+      const projectName = $('name').value.trim() || 'latest';
+      const url = $('url').value.trim();
+      const viewportWidth = parseNumber($('width').value, 1280);
+      const viewportHeight = parseNumber($('height').value, 720);
+      const outputResolution = $('outRes').value || '1280x720';
+      const fpsFinal = parseNumber($('fpsFinal').value, 24);
+      const crf = parseNumber($('crf').value, 18);
+      const preset = $('preset').value || 'veryfast';
+      const shotsRaw = $('shots').value.trim() || '[]';
+
+      if (!url) {
+        throw new Error('URL-ul este obligatoriu.');
+      }
+
+      let shots;
+      try {
+        shots = JSON.parse(shotsRaw);
+      } catch (_error) {
+        throw new Error('Shots JSON nu este valid.');
+      }
+
+      if (!Array.isArray(shots)) {
+        throw new Error('Shots JSON trebuie să fie un array.');
+      }
+
+      return {
+        filename: `plans/${slugify(projectName)}.plan.json`,
+        data: {
+          url,
+          viewport: {
+            width: viewportWidth,
+            height: viewportHeight
+          },
+          output: {
+            outputResolution,
+            fpsFinal,
+            crf,
+            preset
+          },
+          shots
+        }
+      };
+    }
+
+    function downloadJsonFile(filename, data) {
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename.split('/').pop();
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(link.href);
+    }
+
     function setStatus(text) {
       $('status').textContent = text;
     }
@@ -280,11 +351,23 @@
       }
     }
 
+    function exportPlan() {
+      try {
+        const { filename, data } = buildPlanFromForm();
+        downloadJsonFile(filename, data);
+        setStatus(`Plan exportat: ${filename}\n\n${JSON.stringify(data, null, 2)}`);
+      } catch (error) {
+        setStatus(`Export eșuat: ${error.message}`);
+        alert(error.message);
+      }
+    }
+
     $('loadPreset1').addEventListener('click', () => applyPreset(0));
     $('loadPreset2').addEventListener('click', () => applyPreset(1));
     $('loadPreset3').addEventListener('click', () => applyPreset(2));
     $('runBtn').addEventListener('click', runJob);
     $('healthBtn').addEventListener('click', healthCheck);
+    $('exportPlanBtn').addEventListener('click', exportPlan);
 
     $('backendUrl').addEventListener('change', () => {
       localStorage.setItem('backendUrl', $('backendUrl').value.trim());


### PR DESCRIPTION
### Motivation

- Provide a simple way to export a runner-compatible plan JSON from the UI so the existing `scripts/run-plan.mjs` / runner can consume it directly.
- Generate a predictable filename (`plans/<slug>.plan.json`) so exported plans work with the repository workflows that look for `plans/*.plan.json`.
- Validate required fields (`url`, `shots` JSON) client-side to prevent invalid exports.

### Description

- Added an `Export plan` button (`id="exportPlanBtn"`) to the main toolbar in `public/index.html` and wired it to an `exportPlan()` handler.
- Implemented helper functions: `slugify`, `parseNumber`, `buildPlanFromForm`, and `downloadJsonFile` inside `public/index.html` to build the payload and trigger a JSON download.
- `buildPlanFromForm()` builds the exported object with the shape expected by the runner: `{ url, viewport, output, shots }`, and returns a filename of the form `plans/<project-slug>.plan.json`.
- Client-side validation ensures `url` is present and `shots` is valid JSON and an array; validation errors are shown via `alert()` and the status panel, and successful export updates the status panel with the exported plan preview.

### Testing

- Ran `npm run validate` which executed `scripts/validate-inline-scripts.mjs` and reported success: "Validated 1 inline <script> blocks in public/index.html".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e679434db88322a3f4c75cd3893769)