### PR TITLE
Fix GitHub Pages deployment packaging and add troubleshooting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,10 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
       - name: Prepare static site
         run: |
           mkdir -p dist
-          cp public/index.html dist/index.html
+          cp -R public/. dist/
+          touch dist/.nojekyll
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ http://localhost:3000
   - artifactul este atașat rulării din Actions;
   - release asset-ul este atașat release-ului/tag-ului.
 
+
+## Troubleshooting GitHub Pages
+
+Dacă pagina publicată nu se deschide, verifică în această ordine:
+
+1. **Settings → Pages → Source = GitHub Actions**
+2. Rulează manual workflow-ul **Deploy Pages** din tab-ul **Actions** (sau fă un push nou pe `main`).
+3. După deploy, fă **hard refresh** în browser (`Ctrl+Shift+R` / `Cmd+Shift+R`).
+
+Workflow-ul de Pages pregătește acum întregul conținut din `public/` (inclusiv `presets.json`) și publică artifactul pentru deploy.
+
 ## Deploy pe Render (Web Service)
 
 Repo-ul include configurare minimă pentru Render:


### PR DESCRIPTION
### Motivation
- Ensure GitHub Pages workflow publishes the full static site (all files in `public/`, e.g. `presets.json`) not only `index.html`, so the hosted site works as expected. 
- Align the Pages workflow with the recommended Pages setup on GitHub Actions by running the pages configuration step. 
- Give users a clear recovery flow when the published site doesn't load (Settings → Pages, rerun Deploy Pages, hard refresh).

### Description
- Updated `.github/workflows/pages.yml` to run `actions/configure-pages@v5` before the build step. 
- Changed the prepare step to copy the entire `public/` tree into `dist` (`cp -R public/. dist/`) and add `dist/.nojekyll`. 
- Kept the artifact upload (`actions/upload-pages-artifact@v3`) and deploy (`actions/deploy-pages@v4`) steps intact so the new `dist` is published. 
- Added a `Troubleshooting GitHub Pages` section to `README.md` documenting: set **Source = GitHub Actions**, run the `Deploy Pages` workflow (or push `main`), and perform a hard refresh.

### Testing
- Ran `npm run validate` which executed `node scripts/validate-inline-scripts.mjs public/index.html` and reported success (`Validated 1 inline <script> blocks`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e731d10a788322b6666475f232a69a)